### PR TITLE
Add pwm control to motors

### DIFF
--- a/partD2.c
+++ b/partD2.c
@@ -10,6 +10,7 @@
 #include <linux/module.h>
 #include <linux/kernel.h>	/* printk() */
 #include <linux/gpio.h>
+#inlcude <linux/pwm.h>
 
 #include <linux/slab.h>		/* kmalloc() */
 #include <linux/fs.h>		/* everything... */

--- a/partD2.c
+++ b/partD2.c
@@ -10,7 +10,6 @@
 #include <linux/module.h>
 #include <linux/kernel.h>	/* printk() */
 #include <linux/gpio.h>
-#inlcude <linux/pwm.h>
 
 #include <linux/slab.h>		/* kmalloc() */
 #include <linux/fs.h>		/* everything... */


### PR DESCRIPTION
Added PWM to kernel module code in PartD2.c. Uses linux/pwm.h. Need to enable both PWM channels in /boot/config.txt in order for this to work. Allows for students to slow down the robot so it is easier to control on the ground. 